### PR TITLE
fix: validate against blank passwords

### DIFF
--- a/apps/core/internal/request/authenticate_request.go
+++ b/apps/core/internal/request/authenticate_request.go
@@ -18,7 +18,7 @@ func (r AuthenticateRequest) Validate() error {
 		errs = append(errs, fmt.Errorf("email is invalid"))
 	}
 
-	if len(r.Password) < 8 {
+	if len(strings.TrimSpace(r.Password)) < 8 {
 		errs = append(errs, fmt.Errorf("password is too short"))
 	}
 

--- a/apps/core/internal/request/authenticate_request_test.go
+++ b/apps/core/internal/request/authenticate_request_test.go
@@ -26,6 +26,14 @@ func TestValidateAuthenticationRequest(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("it should return an error if the password is made of empty spaces", func(t *testing.T) {
+		t.Parallel()
+
+		req := request.AuthenticateRequest{Email: "mail@domain.tld", Password: "        "}
+		err := req.Validate()
+		require.Error(t, err)
+	})
+
 	t.Run("it should validate the request", func(t *testing.T) {
 		t.Parallel()
 

--- a/apps/core/internal/request/authenticate_request_test.go
+++ b/apps/core/internal/request/authenticate_request_test.go
@@ -21,15 +21,7 @@ func TestValidateAuthenticationRequest(t *testing.T) {
 	t.Run("it should return an error if the password is too short", func(t *testing.T) {
 		t.Parallel()
 
-		req := request.AuthenticateRequest{Email: "mail@domain.tld", Password: "short"}
-		err := req.Validate()
-		require.Error(t, err)
-	})
-
-	t.Run("it should return an error if the password is made of empty spaces", func(t *testing.T) {
-		t.Parallel()
-
-		req := request.AuthenticateRequest{Email: "mail@domain.tld", Password: "        "}
+		req := request.AuthenticateRequest{Email: "mail@domain.tld", Password: "short      "}
 		err := req.Validate()
 		require.Error(t, err)
 	})

--- a/apps/core/internal/request/create_user_request.go
+++ b/apps/core/internal/request/create_user_request.go
@@ -18,7 +18,7 @@ func (r CreateUserRequest) Validate() error {
 		errs = append(errs, fmt.Errorf("email is invalid"))
 	}
 
-	if len(r.Password) < 8 {
+	if len(strings.TrimSpace(r.Password)) < 8 {
 		errs = append(errs, fmt.Errorf("password is too short"))
 	}
 

--- a/apps/core/internal/request/create_user_request_test.go
+++ b/apps/core/internal/request/create_user_request_test.go
@@ -26,6 +26,14 @@ func TestValidateCreateUserRequest(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("it should return an error if the password is made of empty spaces", func(t *testing.T) {
+		t.Parallel()
+
+		req := request.CreateUserRequest{Email: "mail@domain.tld", Password: "        "}
+		err := req.Validate()
+		require.Error(t, err)
+	})
+
 	t.Run("it should validate the request", func(t *testing.T) {
 		t.Parallel()
 

--- a/apps/core/internal/request/create_user_request_test.go
+++ b/apps/core/internal/request/create_user_request_test.go
@@ -21,19 +21,11 @@ func TestValidateCreateUserRequest(t *testing.T) {
 	t.Run("it should return an error if the password is too short", func(t *testing.T) {
 		t.Parallel()
 
-		req := request.CreateUserRequest{Email: "mail@domain.tld", Password: "short"}
+		req := request.CreateUserRequest{Email: "mail@domain.tld", Password: "short      "}
 		err := req.Validate()
 		require.Error(t, err)
 	})
-
-	t.Run("it should return an error if the password is made of empty spaces", func(t *testing.T) {
-		t.Parallel()
-
-		req := request.CreateUserRequest{Email: "mail@domain.tld", Password: "        "}
-		err := req.Validate()
-		require.Error(t, err)
-	})
-
+	
 	t.Run("it should validate the request", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
> I am open to contributions. If you want to land a hand, please open an issue or a pull request. I will work on the contribution guidelines soon.

Your note was very welcoming, so... I thought I could start somewhere. 

### Changes

- Updated the request validator functions to account for passwords with blank characters such as `        `;
- Added test cases to assert against blank passwords;

### Potential follow up

- The test cases in the `request` package are good candidates to be written in a table-driven manner given how simple they are to setup.